### PR TITLE
Typo in updated link for KNIME API Token

### DIFF
--- a/docs/knime.html
+++ b/docs/knime.html
@@ -61,7 +61,7 @@
                   <img src="knime_dw-config.png" class="img-fluid rounded" style="box-shadow:7px 7px 30px grey;">
               </div>
               <div class="alert alert-info col-sm-9 border" style="margin-top:2em; font-weight:300;">
-              You can access your API token from data.world's <a href="https://data.world/integrations/knime?tab=settings" target="_blank">KNIME integration page/a>.
+              You can access your API token from data.world's <a href="https://data.world/integrations/knime?tab=settings" target="_blank">KNIME integration page</a>.
               </div>
               
 </ol>


### PR DESCRIPTION
Fixing a type in the API link for KNIME (was missing "<", causing incorrect display.)